### PR TITLE
 Limits the JTAC spawns we carry over to next state.

### DIFF
--- a/ctld.lua
+++ b/ctld.lua
@@ -103,9 +103,9 @@
  -- When this limit is hit, a player will still be able to get crates for an AA system, just unable
  -- to unpack them
  
- ctld.AASystemLimitRED = 20 -- Red side limit
+ ctld.AASystemLimitRED = 10 -- Red side limit
  
- ctld.AASystemLimitBLUE = 20 -- Blue side limit
+ ctld.AASystemLimitBLUE = 10 -- Blue side limit
  
  --END AA SYSTEM CONFIG --
  

--- a/exporter.lua
+++ b/exporter.lua
@@ -10,27 +10,50 @@ end
 mist.scheduleFunction(write_state, {}, timer.getTime() + 524, 580)
 
 -- update list of active CTLD AA sites in the global game state
-function enumerateCTLD()
+function countHawkSites()
     local CTLDstate = {}
-    log("Enumerating CTLD")
+    log("Counting the number of HAWK sites.")
+    local hawkCount = 0
     for _groupname, _groupdetails in pairs(ctld.completeAASystems) do
         local CTLDsite = {}
         for k,v in pairs(_groupdetails) do
             CTLDsite[v['unit']] = v['point']
         end
         CTLDstate[_groupname] = CTLDsite
+        hawkCount = hawkCount + 1
     end
     game_state["Theaters"]["Russian Theater"]["Hawks"] = CTLDstate
-    log("Done Enumerating CTLD")
+    log("Done counting Hawks. Found " .. tostring(hawkCount) .. " sites")
+end
+
+
+function sortByCreationTime(a, b)
+  --TODO: handle nil..
+  return a["creationTime"] > b["creationTime"]
+end
+
+function limitCTLDByType(typ, num)
+  local _ignored = {} -- We hold the types we don't care about in here
+  local _limited = {} -- holds the types we're limiting by
+  for _, v in pairs(game_state["Theaters"]["Russian Theater"]["CTLD_ASSETS"]) do
+    if v["name"] ~= typ then
+      table.insert(_ignored, v)
+    else
+      log(typ .. " are at " .. tostring(#_limited) .. "/" .. tostring(num))
+      table.insert(_limited, v)
+    end
+  end
+  table.sort(_limited, sortByCreationTime) -- In place.
+  _limited = { unpack(_limited, 1, 5 ) }
+
+  game_state["Theaters"]["Russian Theater"]["CTLD_ASSETS"] = TableConcat(_ignored, _limited)
 end
 
 ctld.addCallback(function(_args)
     if _args.action and _args.action == "unpack" then
         local name
         local groupname = _args.spawnedGroup:getName()
-        if string.match(groupname, "Hawk") then
-            name = "hawk"
-        elseif string.match(groupname, "Avenger") then
+        if string.match(groupname, "Avenger") then
             name = "avenger"
         elseif string.match(groupname, "M 818") then
             name = 'ammo'
@@ -42,12 +65,18 @@ ctld.addCallback(function(_args)
             name = 'jtac'
         end
 
+        --We don't care about the drop if it's not one of the above.
+        if not name then
+          return
+        end
+
         table.insert(game_state["Theaters"]["Russian Theater"]["CTLD_ASSETS"], {
             name=name,
-            pos=GetCoordinate(Group.getByName(groupname))
+            pos=GetCoordinate(Group.getByName(groupname)),
+            creationTime = os.time() -- This is unsanitized, right?
         })
-
-        enumerateCTLD()
+        countHawkSites()
+        limitCTLDByType('jtac', 7)
         write_state()
     end
 end)

--- a/init.lua
+++ b/init.lua
@@ -187,9 +187,13 @@ if statefile then
                 x = data.pos.x,
                 y = data.pos.z
             })
-            local _code = table.remove(ctld.jtacGeneratedLaserCodes, 1)
-            table.insert(ctld.jtacGeneratedLaserCodes, _code)
-            ctld.JTACAutoLase(_spawnedGroup:getName(), _code)
+            if _spawnedGroup then
+              local _code = table.remove(ctld.jtacGeneratedLaserCodes, 1)
+              table.insert(ctld.jtacGeneratedLaserCodes, _code)
+              ctld.JTACAutoLase(_spawnedGroup:getName(), _code)
+            else
+              log("Failed to spawn a jtac from state")
+            end
         end
     end
 

--- a/utils.lua
+++ b/utils.lua
@@ -49,3 +49,10 @@ end
 function addstddev(val, sigma)
     return val + math.random(-sigma, sigma)
 end
+
+TableConcat = function(t1,t2)
+    for i=1,#t2 do
+        t1[#t1+1] = t2[i]
+    end
+    return t1
+end


### PR DESCRIPTION
 - JTACs were already not persisted through more than one cycle.
 - Now, only the 7 most recently placed ones will be persisted across
   cycles.
 - Removed some hawk site handling since we don't do it in the
   CTLD_ASSETS section anymore.